### PR TITLE
Fix an issue where EMAIL isn't passed into renew cron

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,6 +12,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:cron]
 command = cron -f -L 15
+environment=EMAIL="%(ENV_EMAIL)s"
 autostart=true
 autorestart=true
 redirect_stderr=true


### PR DESCRIPTION
When using supervisord, you must explicitly pass in environment variables through the configuration otherwise cert renewal script will crash.

https://stackoverflow.com/questions/36482324/pass-environment-variable-from-docker-to-supervisord explains the fix

Closes #5