### PR TITLE
Add ability to test against let's encrypt staging servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,6 @@ EXPOSE 80 443
 
 VOLUME /etc/letsencrypt
 
+ENV STAGING=false
+
 ENTRYPOINT ["/bootstrap.sh"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Example of run command (replace CERTS,EMAIL values and volume paths with yours)
 docker run --name lb -d \
     -e CERTS=my.domain,my.other.domain \
     -e EMAIL=my.email@my.domain \
+    -e STAGING=false \
     -v /srv/letsencrypt:/etc/letsencrypt \
     -v /srv/haproxycfg/haproxy.cfg:/etc/haproxy/haproxy.cfg \
     --network my_network \
@@ -46,6 +47,7 @@ services:
         environment:
             - CERTS=my.domain
             - EMAIL=my.mail
+            - STAGING=false
         volumes:
             - '$PWD/data/letsencrypt:/etc/letsencrypt'
             - '$PWD/data/haproxy.cfg:/etc/haproxy/haproxy.cfg'

--- a/run/docker-compose.yml
+++ b/run/docker-compose.yml
@@ -5,6 +5,7 @@ services:
         environment:
             - CERTS=my.domain
             - EMAIL=my.mail
+            - STAGING=false
         volumes:
             - '$PWD/data/letsencrypt:/etc/letsencrypt'
             - '$PWD/data/haproxy.cfg:/etc/haproxy/haproxy.cfg'

--- a/scripts/certs.sh
+++ b/scripts/certs.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
 if [ -n "$CERTS" ]; then
-    certbot certonly --no-self-upgrade -n --text --standalone \
+    if [ "$STAGING" = true ]; then
+        certbot certonly --no-self-upgrade -n --text --standalone \
+        --preferred-challenges http-01 \
+	--staging \
+        -d "$CERTS" --keep --expand --agree-tos --email "$EMAIL" \
+        || exit 2
+    else
+    	certbot certonly --no-self-upgrade -n --text --standalone \
         --preferred-challenges http-01 \
         -d "$CERTS" --keep --expand --agree-tos --email "$EMAIL" \
         || exit 1
+    fi
 
     mkdir -p /etc/haproxy/certs
     for site in `ls -1 /etc/letsencrypt/live | grep -v ^README$`; do


### PR DESCRIPTION
Added an environment variable "STAGING" to the build. This will allow people to run the contain against let's encrypt's staging environment which has a higher rate limits.

It defaults to false so if it's not specified then it will run like it does now, in production mode.

I have updated the docker-compose file to show how it can be used as well

I have not updated the certificate renewal scripts to take into account staging certificates because my use case has been to test the signing and issuing process so far.